### PR TITLE
v0.2.8-rc.2

### DIFF
--- a/src/bytecode/mod.rs
+++ b/src/bytecode/mod.rs
@@ -141,7 +141,7 @@ use super::Inst::*;
 #[cfg(test)]
 mod tests;
 
-#[cfg(not(feature = "nightly"))]
+#[cfg(not(feature = "nightly")]
 macro_rules! push_all {
     ( $vec:ident, $other:expr ) => {
         for item in $other {
@@ -155,9 +155,9 @@ macro_rules! push_all {
 }
 
 /// exported constants
-#[stable(feature="decode", since="0.3.0")]
+#[cfg_attr(feature = "nightly", stable(feature="decode", since="0.3.0"))]
 pub const IDENT_BYTES: u16 = 0x5ECD;
-#[stable(feature="decode", since="0.3.0")]
+#[cfg_attr(feature = "nightly", stable(feature="decode", since="0.3.0"))]
 pub const VERSION: u16     = 0x0000;
 
 /// block reserved for future opcodes
@@ -170,7 +170,7 @@ const CONST_LEN: u8       = 0x0E;
 const BYTE_CONS: u8       = 0xC0;
 const BYTE_NIL: u8        = 0x00;
 
-#[unstable(feature = "decode")]
+#[cfg_attr(feature = "nightly", unstable(feature = "decode"))]
 pub fn decode_program<R>(source: &mut R) -> Result<List<SVMCell>, String>
     where R: Read
 {
@@ -183,13 +183,13 @@ pub fn decode_program<R>(source: &mut R) -> Result<List<SVMCell>, String>
         .map(|_| decoder.collect::<List<SVMCell>>() )
 }
 
-#[stable(feature="decode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
 pub struct Decoder<'a, R: 'a> {
     source: &'a mut R,
     num_read: usize
 }
 
-#[stable(feature="decode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
 fn decode_inst(byte: &u8) -> Result<Inst, String> {
     match *byte {
         BYTE_NIL => Ok(NIL),
@@ -232,11 +232,11 @@ fn decode_inst(byte: &u8) -> Result<Inst, String> {
 }
 
 
-#[stable(feature="decode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
 impl<'a, R> Decoder<'a, R>
     where R: Read
 {
-    #[stable(feature="decode", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.3.0"))]
     pub fn check_ident_bytes(&mut self) -> Result<(), String> {
         self.source
             .read_u16::<BigEndian>()
@@ -252,7 +252,7 @@ impl<'a, R> Decoder<'a, R>
             })
     }
 
-    #[stable(feature="decode", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.3.0"))]
     pub fn check_version(&mut self) -> Result<(), String> {
         self.source
             .read_u16::<BigEndian>()
@@ -270,7 +270,7 @@ impl<'a, R> Decoder<'a, R>
             })
     }
 
-    #[stable(feature="decode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
     pub fn new(src: &'a mut R) -> Decoder<'a, R> {
         Decoder {
             source: src,
@@ -279,12 +279,12 @@ impl<'a, R> Decoder<'a, R>
     }
 
     /// Returns the number of bytes read by the decoder
-    #[stable(feature="decode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
     pub fn num_read(&self) -> usize {
         self.num_read
     }
 
-    #[stable(feature="decode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
     fn decode_const(&mut self, byte: &u8) -> Result<Atom, String> {
         match *byte & 0x0F { // extract the type tag
             1 => {
@@ -323,7 +323,7 @@ impl<'a, R> Decoder<'a, R>
         }
     }
     // Decodes a CONS cell
-    #[stable(feature="decode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
     fn decode_cons(&mut self) -> Result<Option<Box<List<SVMCell>>>, String> {
         self.next_cell()
             .and_then(|car|
@@ -354,7 +354,7 @@ impl<'a, R> Decoder<'a, R>
     }
 
     /// Decodes the next cell in the source
-    #[stable(feature="decode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
     pub fn next_cell(&mut self) -> Result<Option<SVMCell>,String> {
         let mut buf = [0;1];
         match self.source.read(&mut buf) {
@@ -385,20 +385,20 @@ impl<'a, R> Decoder<'a, R>
 
 }
 
-#[stable(feature="decode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
 impl<'a, R> Iterator for Decoder<'a, R> where R: Read {
-    #[stable(feature="decode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
     type Item = SVMCell;
 
-    #[stable(feature="decode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
     fn next(&mut self) -> Option<SVMCell> {
         self.next_cell()
             .unwrap()
     }
 }
-#[stable(feature="decode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
 impl<'a, R> fmt::Debug for Decoder<'a, R>  where R: fmt::Debug {
-    #[stable(feature="decode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="decode", since="0.2.6"))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "Decoding from: {:?}, {} bytes read",
             self.source,
@@ -408,15 +408,15 @@ impl<'a, R> fmt::Debug for Decoder<'a, R>  where R: fmt::Debug {
 
 }
 
-#[stable(feature="encode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
 pub trait Encode {
-    #[stable(feature="encode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
     fn emit(&self) -> Vec<u8>;
 }
 
-#[stable(feature="encode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
 impl Encode for SVMCell {
-    #[stable(feature="encode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
     fn emit(&self) -> Vec<u8> {
         match *self {
             AtomCell(ref atom) => atom.emit(),
@@ -426,9 +426,9 @@ impl Encode for SVMCell {
     }
 }
 
-#[stable(feature="encode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
 impl Encode for Atom {
-    #[stable(feature="encode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
     fn emit(&self) -> Vec<u8> {
         match *self {
             UInt(value) => {
@@ -459,9 +459,9 @@ impl Encode for Atom {
     }
 }
 
-#[stable(feature="encode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
 impl Encode for Inst {
-    #[stable(feature="encode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
     fn emit(&self) -> Vec<u8> {
         match *self {
             NIL     => vec![BYTE_NIL],
@@ -498,9 +498,9 @@ impl Encode for Inst {
     }
 }
 
-#[stable(feature="encode", since="0.2.6")]
+#[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
 impl<T> Encode for List<T> where T: Encode {
-    #[stable(feature="encode", since="0.2.6")]
+    #[cfg_attr(feature = "nightly", stable(feature="encode", since="0.2.6"))]
     fn emit(&self) -> Vec<u8> {
         match *self {
             Cons(ref it, ref tail) => {

--- a/src/bytecode/mod.rs
+++ b/src/bytecode/mod.rs
@@ -141,7 +141,7 @@ use super::Inst::*;
 #[cfg(test)]
 mod tests;
 
-#[cfg(not(feature = "nightly")]
+#[cfg(not(feature = "nightly"))]
 macro_rules! push_all {
     ( $vec:ident, $other:expr ) => {
         for item in $other {

--- a/src/cell.rs
+++ b/src/cell.rs
@@ -6,7 +6,7 @@ use ::slist::List;
 use std::{fmt,ops};
 
 #[macro_export]
-#[unstable(feature = "list")]
+#[cfg_attr(feature = "nightly", unstable(feature = "list"))]
 macro_rules! list_cell {
     [ $first:expr, $($rest:expr),+ ] => {
         ListCell(Box::new( list!( $first, $( $rest),+ ) ))
@@ -19,26 +19,26 @@ macro_rules! list_cell {
 }
 
 #[derive(PartialEq,Clone)]
-#[stable(feature="vm_core", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
 pub enum SVMCell {
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     AtomCell(Atom),
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     ListCell(Box<List<SVMCell>>),
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     InstCell(Inst)
 }
 
-#[stable(feature="vm_core", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
 impl fmt::Display for SVMCell {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self)
     }
 }
 
-#[stable(feature="debug", since="0.2.1")]
+#[cfg_attr(feature = "nightly", stable(feature="debug", since="0.2.1"))]
 impl fmt::Debug for SVMCell {
-    #[stable(feature="debug", since="0.2.1")]
+    #[cfg_attr(feature = "nightly", stable(feature="debug", since="0.2.1"))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             &AtomCell(atom) => write!(f, "{:?}", atom),
@@ -52,24 +52,24 @@ impl fmt::Debug for SVMCell {
 ///
 /// A VM atom can be either an unsigned int, signed int, float, or char.
 #[derive(PartialEq,PartialOrd,Copy,Clone)]
-#[stable(feature="vm_core", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
 pub enum Atom {
     /// Unsigned integer atom (machine 64)
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     UInt(u64),
     /// Signed integer atom (machine 64)
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     SInt(i64),
     /// Floating point number atom (64-bits)
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     Float(f64),
     /// UTF-8 character atom
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     Char(char)
 }
-#[stable(feature="vm_core", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
 impl fmt::Display for Atom {
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             &Atom::UInt(value) => write!(f, "{}", value),
@@ -80,9 +80,9 @@ impl fmt::Display for Atom {
     }
 }
 
-#[stable(feature="debug", since="0.2.1")]
+#[cfg_attr(feature = "nightly", stable(feature="debug", since="0.2.1"))]
 impl fmt::Debug for Atom {
-    #[stable(feature="debug", since="0.2.1")]
+    #[cfg_attr(feature = "nightly", stable(feature="debug", since="0.2.1"))]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             &Atom::UInt(value) => write!(f, "{:?}u", value),
@@ -93,11 +93,11 @@ impl fmt::Debug for Atom {
     }
 }
 
-#[stable(feature="vm_core", since="0.3.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
 impl ops::Add for Atom {
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     type Output = Atom;
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     fn add(self, other: Atom) -> Atom {
         match (self, other) {
             // same type:  no coercion
@@ -127,11 +127,11 @@ impl ops::Add for Atom {
     }
 
 }
-#[stable(feature="vm_core", since="0.3.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
 impl ops::Sub for Atom {
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     type Output = Atom;
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     fn sub(self, other: Atom) -> Atom {
         match (self, other) {
             // same type:  no coercion
@@ -158,11 +158,11 @@ impl ops::Sub for Atom {
     }
 
 }
-#[stable(feature="vm_core", since="0.3.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
 impl ops::Div for Atom {
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     type Output = Atom;
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     fn div(self, other: Atom) -> Atom {
         match (self, other) {
             // same type:  no coercion
@@ -189,12 +189,12 @@ impl ops::Div for Atom {
     }
 
 }
-#[stable(feature="vm_core", since="0.3.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
 impl ops::Mul for Atom {
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     type Output = Atom;
 
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     fn mul(self, other: Atom) -> Atom {
         match (self, other) {
             // same type:  no coercion
@@ -221,12 +221,12 @@ impl ops::Mul for Atom {
     }
 
 }
-#[stable(feature="vm_core", since="0.3.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
 impl ops::Rem for Atom {
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     type Output = Atom;
 
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     fn rem(self, other: Atom) -> Atom {
         match (self, other) {
             // same type:  no coercion
@@ -263,7 +263,7 @@ impl ops::Rem for Atom {
 ///  + `(x.y)` is `Cons(x, y)`. The empty list is `nil`.
 ///  + each instruction is described as a state transition `(s, e, c, d) → (s´, e´, c´, d´)`
 #[derive(Debug,Copy,Clone,PartialEq)]
-#[stable(feature="vm_core", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
 pub enum Inst {
     /// `nil`
     ///
@@ -271,10 +271,10 @@ pub enum Inst {
     ///
     /// __Operational semantics__: `(s, e, (NIL.c), d) → ( (nil.s), e, c, d )`
     ///
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     NIL,
     /// `ldc`: `L`oa`d` `C`onstant. Loads a constant (atom)
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     LDC,
     /// `ld`: `L`oa`d`. Pushes a variable onto the stack.
     ///
@@ -285,7 +285,7 @@ pub enum Inst {
     ///
     /// __Operational semantics__: `(s, e, LDC.v.c, d) → (v.s, e, c, d)`
     ///
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     LD,
     /// `ldf`: `L`oa`d` `F`unction.
     ///
@@ -295,7 +295,7 @@ pub enum Inst {
     ///
     /// _Operational semantics_: `(s, e, (LDF f.c), d) → ( ([f e].s), e, c, d)`
     ///
-    #[stable(feature="vm_core", since="0.2.4")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.2.4"))]
     LDF,
     /// `join`
     ///
@@ -305,7 +305,7 @@ pub enum Inst {
     ///
     /// __Operational semantics__: `(s, e, JOIN.c, c´.d) → (s, e, c´, d)`
     ///
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     JOIN,
     /// `ap`: `Ap`ply.
     ///
@@ -318,25 +318,25 @@ pub enum Inst {
     ///
     /// __Operational semantics__: `(([f e´] v.s), e, (AP.c), d) → (nil, (v.e&prime), f, (s e c.d))`
     ///
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     AP,
     /// `ret`: `Ret`urn.
     ///
     /// Pops one return value from the stack, restores
     /// `$s`, `$e`, and `$c` from the dump, and pushes
     /// the return value onto the now-current stack.
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     RET,
     /// `dum`: `Dum`my.
     ///
     /// Pops a dummy environment (an empty list) onto the `$e` stack.
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     DUM,
     /// `rap`: `R`ecursive `Ap`ply.
     /// Works like `ap`, only that it replaces an occurrence of a
     /// dummy environment with the current one, thus making recursive
     ///  functions possible.
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     RAP,
     /// `sel`: `Sel`ect branch
     ///
@@ -348,7 +348,7 @@ pub enum Inst {
     ///
     /// __Operational semantics__: `(v.s, e, SEL.true.false.c, d) → (s, e, (if v then true else false), c.d)`
     ///
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     SEL,
     /// `add`
     ///
@@ -358,7 +358,7 @@ pub enum Inst {
     ///
     /// TODO: figure out what happens when you try to add things that aren't
     /// numbers (maybe the compiler won't let this happen?).
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     ADD,
     /// `sub`: `Sub`tract
     ///
@@ -368,7 +368,7 @@ pub enum Inst {
     ///
     /// TODO: figure out what happens when you try to subtract things that
     /// aren't numbers (maybe the compiler won't let thi64 happen?).
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     SUB,
     /// `mul`: `Mul`tiply
     ///
@@ -378,7 +378,7 @@ pub enum Inst {
     ///
     /// TODO: figure out what happens when you try to multiply things that
     /// aren't numbers (maybe the compiler won't let thi64 happen?).
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     MUL,
     /// `div`: `Div`ide
     ///
@@ -387,7 +387,7 @@ pub enum Inst {
     ///
     /// TODO: figure out what happens when you try to divide things that
     /// aren't numbers (maybe the compiler won't let thi64 happen?).
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     DIV,
     /// `fdiv`: `F`loating-point `div`ide
     ///
@@ -399,7 +399,7 @@ pub enum Inst {
     ///
     /// TODO: Not sure if there should be separate float and int divide words
     /// I guess the compiler can figure this out
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     FDIV,
     /// `mod`: `Mod`ulo
     ///
@@ -408,77 +408,77 @@ pub enum Inst {
     ///
     /// TODO: figure out what happens when you try to modulo things that
     /// aren't numbers (maybe the compiler won't let this happen?).
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     MOD,
     /// `eq`: `Eq`uality of atoms
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     EQ,
     /// `gt`: `G`reater `t`han
     ///
     /// Pops two numbers on the stack and puts a 'true' on the stack
     /// if the first atom i64 greater than the other atom, false otherwi64e.
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     GT,
     /// `gte`: `G`reater `t`han or `e`qual
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     GTE,
     /// `lt`: `L`ess `t`han
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     LT,
     /// `lte`: `L`ess `t`han or `e`qual
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     LTE,
     /// `atom`: test if `atom`
     ///
     /// Pops an item from the stack and returns true if it's an atom, false
     /// otherwise.
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     ATOM,
     /// `car`: `C`ontents of `A`ddress `R`egister
     ///
     /// Pops a list from the stack and returns the list's `car` (head)
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     CAR,
     /// `cdr`: `C`ontents of `D`ecrement `R`egister
     ///
     /// Pops a list from the stack and returns the list's `cdr` (tail)
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     CDR,
     /// `cons`: `Cons`truct
     ///
     /// Pops an item and a list from the stack and returns the list, with
     /// the item prepended.
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     CONS,
     /// `null`: test if `null`
     ///
     ///  Pops an item from the stack and returns true if it is `nil`, false
     ///  otherwise.
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     NULL,
     /// `stop`: `stop` execution
     ///
     /// Terminates program execution. The `eval_program()` function will return
     /// the last state of the VM.
-    #[stable(feature="vm_core", since="0.1.2")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.2"))]
     STOP,
     /// `readc`: `read` `c`haracter
     ///
     /// Reads a character from the machine's input stream and places it
     /// on top of the stack
-    #[stable(feature="vm_io", since="0.2.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_io", since="0.2.0"))]
     READC,
     /// `writec`: `write` `c`haracter
     ///
     /// Writes a character from the top of the stack to the machine's
     /// output stream.
-    #[stable(feature="vm_io", since="0.2.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_io", since="0.2.0"))]
     WRITEC,
     /// `apcc`: `ap`ply with `c`urrent `c`ontinuation
     ///
     /// Applies a closure and captures the continuation that can
     /// then be applied with `ap`.
-    #[unstable(feature="callcc")]
+    #[cfg_attr(feature = "nightly", unstable(feature="callcc"))]
     APCC,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![crate_name = "seax_svm"]
-#![stable(feature="vm_core", since="0.1.2")]
+#![stable(feature="vm_core", since="0.1.2"))]
 #![crate_type = "lib"]
 #![cfg_attr(test, feature(test))]
 #![cfg_attr(feature = "nightly",
@@ -24,7 +24,7 @@ extern crate byteorder;
 /// `Stack<T>` is a trait providing stack operations(`push()`, `pop()`, and
 /// `peek()`), and an implementation for `List`.
 #[macro_use]
-#[stable(feature="list", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0"))]
 pub mod slist;
 
 /// SVM cell types.
@@ -33,10 +33,10 @@ pub mod slist;
 /// int, signed int, float, or string), a pointer to a list cell, or an
 /// instruction.
 #[macro_use]
-#[stable(feature="vm_core", since="0.1.2")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.2"))]
 pub mod cell;
 
-#[unstable(feature="bytecode")]
+#[unstable(feature="bytecode"))]
 pub mod bytecode;
 
 #[cfg(test)]
@@ -56,7 +56,7 @@ use self::cell::Inst::*;
 
 /// Represents a SVM machine state
 #[derive(PartialEq,Clone,Debug)]
-#[stable(feature="vm_core", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
 pub struct State {
     stack:  List<SVMCell>,
     env:    List<SVMCell>,
@@ -71,7 +71,7 @@ pub struct State {
 /// never be marked as stable. Consider this struct and anything that depends
 /// on it to be an ugly hack.
 #[derive(PartialEq,Clone,Debug)]
-#[unstable(feature="eval")]
+#[cfg_attr(feature = "nightly", unstable(feature="eval"))]
 pub enum IOEvent {
     /// A character was requested from the buffer
     Req,
@@ -79,14 +79,14 @@ pub enum IOEvent {
     Buf(char)
 }
 
-#[unstable(feature="eval")]
+#[cfg_attr(feature = "nightly", unstable(feature="eval"))]
 pub type EvalResult = Result<(State,Option<IOEvent>), String>;
 
-#[stable(feature="vm_core", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
 impl State {
 
     /// Creates a new empty state
-    #[stable(feature="vm_core", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.0"))]
     pub fn new() -> State {
         State {
             stack: Stack::empty(),
@@ -102,7 +102,7 @@ impl State {
     /// This produces state dumps suitable for printing as part of
     /// an error report. This is different from fmt::Debug since it
     /// includes a tag for the error reporter.
-    #[stable(feature="debug", since="0.2.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="debug", since="0.2.0"))]
     pub fn dump_state(&self, tag: &str) -> String {
         format!(
             "[{t}] State dump:\n[{t}]\t\tStack:\t {s:?}\n[{t}]\t\tEnv:\t {e:?}\n[{t}]\t\tControl: {c:?}\n[{t}]\t\tDump:\t {d:?}\n",
@@ -124,7 +124,7 @@ impl State {
     ///  - `outp`: an output stream implementing `io::Write`
     ///  - `debug`: whether or not to snapshot the state before evaluating. This provides more detailed debugging information on errors, but may have a significant impact on performance.
     ///
-    #[stable(feature="vm_core", since="0.3.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     pub fn eval(self,
                 input: Option<u8>,
                 debug: bool)
@@ -751,7 +751,7 @@ impl State {
 ///
 /// Evaluates a program (control stack) and returns the final state.
 /// TODO: add (optional?) parameters for stdin and stdout
-#[stable(feature="vm_core",since="0.2.0")]
+#[cfg_attr(feature = "nightly", stable(feature="vm_core",since="0.2.0"))]
 pub fn eval_program(program: List<SVMCell>,
                     debug: bool)
     -> Result<List<SVMCell>,String> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,14 +1,9 @@
 #![crate_name = "seax_svm"]
-#![stable(feature="vm_core", since="0.1.2"))]
 #![crate_type = "lib"]
+#![cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.2") )]
 #![cfg_attr(test, feature(test))]
-#![cfg_attr(feature = "nightly",
-    feature(
-        vec_push_all,
-        box_patterns,
-        staged_api
-    )
-)]
+#![cfg_attr(feature = "nightly", feature(vec_push_all, box_patterns) )]
+#![cfg_attr(feature = "nightly", feature(staged_api) )]
 #![cfg_attr(feature = "nightly", staged_api)]
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,11 @@ impl State {
     #[cfg_attr(feature = "nightly", stable(feature="debug", since="0.2.0"))]
     pub fn dump_state(&self, tag: &str) -> String {
         format!(
-            "[{t}] State dump:\n[{t}]\t\tStack:\t {s:?}\n[{t}]\t\tEnv:\t {e:?}\n[{t}]\t\tControl: {c:?}\n[{t}]\t\tDump:\t {d:?}\n",
+            "[{t}] State dump:\n \
+             [{t}]\t\tStack:\t {s:?}\n \
+             [{t}]\t\tEnv:\t {e:?}\n \
+             [{t}]\t\tControl: {c:?}\n \
+             [{t}]\t\tDump:\t {d:?}\n",
                 t = tag,
                 s = &self.stack,
                 e = &self.env,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,7 +122,9 @@ impl State {
     ///
     ///  - `inp`: an input stream implementing `io::Read`
     ///  - `outp`: an output stream implementing `io::Write`
-    ///  - `debug`: whether or not to snapshot the state before evaluating. This provides more detailed debugging information on errors, but may have a significant impact on performance.
+    ///  - `debug`: whether or not to snapshot the state before evaluating. This
+    ///     provides more detailed debugging information on errors, but may have
+    ///     a significant impact on performance.
     ///
     #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.3.0"))]
     pub fn eval(self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ pub mod slist;
 #[cfg_attr(feature = "nightly", stable(feature="vm_core", since="0.1.2"))]
 pub mod cell;
 
-#[unstable(feature="bytecode"))]
+#[cfg_attr(feature = "nightly", unstable(feature="bytecode"))]
 pub mod bytecode;
 
 #[cfg(test)]

--- a/src/slist.rs
+++ b/src/slist.rs
@@ -20,7 +20,7 @@ use std::iter::{IntoIterator, FromIterator};
 /// # }
 /// ```
 #[macro_export]
-#[stable(feature="list", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
 macro_rules! list(
     ( $e:expr, $($rest:expr),+ ) => ( Cons($e, Box::new(list!( $( $rest ),+ )) ));
     ( $e:expr ) => ( Cons($e, Box::new(Nil)) );
@@ -28,27 +28,27 @@ macro_rules! list(
 );
 
 /// Common functions for an immutable Stack abstract data type.
-#[stable(feature="stack", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="stack", since="0.1.0") )]
 pub trait Stack<T> {
 
     /// Push an item to the top of the stack, returning a new stack
-    #[stable(feature="stack", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="stack", since="0.1.0") )]
     fn push(self, item : T) -> Self;
 
     /// Pop the top element of the stack. Returns an Option on a T and
     /// a new Stack<T> to replace this.
-    #[stable(feature="stack", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="stack", since="0.1.0") )]
     fn pop(self)            -> Option<(T, Self)>;
 
     /// Peek at the top item of the stack.
     ///
     /// Returns Some<T> if there is an item on top of the stack,
     /// and None if the stack is empty.
-    #[stable(feature="stack", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="stack", since="0.1.0") )]
     fn peek(&self)          -> Option<&T>;
 
     /// Returns an empty stack.
-    #[stable(feature="stack", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="stack", since="0.1.0") )]
     fn empty()              -> Self;
 }
 
@@ -69,7 +69,7 @@ impl<T> Stack<T> for List<T> {
     /// assert_eq!(s.peek(), Some(&6));
     /// ```
     #[inline]
-    #[stable(feature="stack", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="stack", since="0.1.0") )]
     fn push(self, item: T) -> List<T> { Cons(item, Box::new(self)) }
 
     /// Pop the top element of the stack.
@@ -92,7 +92,7 @@ impl<T> Stack<T> for List<T> {
     /// assert_eq!(pop_result.0, 1);
     /// ```
     #[inline]
-    #[stable(feature="stack", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="stack", since="0.1.0") )]
     fn pop(self) -> Option<(T,List<T>)> {
         match self {
             Cons(item, new_self)    => Some((item, *new_self)),
@@ -101,7 +101,9 @@ impl<T> Stack<T> for List<T> {
     }
 
     #[inline]
-    #[stable(feature="stack", since="0.1.0")]
+    #[cfg_attr(feature = "nightly",
+        stable(feature="stack", since="0.1.0")
+    )]
     fn empty() -> List<T> { Nil }
 
     /// Peek at the top element of the stack.
@@ -123,7 +125,7 @@ impl<T> Stack<T> for List<T> {
     /// assert_eq!(pop_result.0, 1);
     /// ```
     #[inline]
-    #[stable(feature="stack", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="stack", since="0.1.0") )]
     fn peek(&self) -> Option<&T> {
         match self {
             &Nil => None,
@@ -147,23 +149,23 @@ impl<T> Stack<T> for List<T> {
 // the performance benefits --- my guess is that caching is worth the added
 // costs (as usual).
 #[derive(PartialEq,Clone)]
-#[stable(feature="list", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
 pub enum List<T> {
     /// Cons cell containing a `T` and a link to the tail
-    #[stable(feature="list", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
     Cons(T, Box<List<T>>),
     /// The empty list.
-    #[stable(feature="list", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
     Nil,
 }
 
 /// Public implementation for List.
-#[stable(feature="list", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
 impl<T> List<T> {
 
 
     /// Creates a new empty list
-    #[stable(feature="list", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
     #[inline]
     pub fn new() -> List<T> { Nil }
 
@@ -194,7 +196,7 @@ impl<T> List<T> {
     /// # }
     /// ```
     #[inline]
-    #[stable(feature="list", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
     pub fn prepend(self, it: T) -> List<T> { Cons(it, Box::new(self)) }
 
     /// Appends an item to the end of the list.
@@ -221,7 +223,7 @@ impl<T> List<T> {
     /// # }
     /// ```
     #[inline]
-    #[stable(feature="list", since="0.2.3")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.3") )]
     pub fn append(&mut self, it: T) {
         match *self {
             Cons(_, ref mut tail) => (*tail).append(it),
@@ -264,7 +266,7 @@ impl<T> List<T> {
     /// assert_eq!(a_list, list![1,2]);
     /// # }
     #[inline]
-    #[stable(feature="list", since="0.2.3")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.3") )]
     pub fn append_chain(&mut self, it: T) -> &mut List<T> {
         match *self {
             Cons(_, ref mut tail) => (*tail).append_chain(it),
@@ -286,7 +288,7 @@ impl<T> List<T> {
     /// # }
     /// ```
     #[inline]
-    #[stable(feature="list", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
     pub fn length (&self) -> usize {
         match *self {
             Cons(_, ref tail) => 1 + tail.length(),
@@ -316,7 +318,7 @@ impl<T> List<T> {
     /// # }
     /// ```
     #[inline]
-    #[stable(feature="list", since="0.2.8")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.8") )]
     pub fn is_empty (&self) -> bool {
         match *self {
             Cons(_,_) => false,
@@ -337,7 +339,7 @@ impl<T> List<T> {
     /// # }
     /// ```
     #[inline]
-    #[stable(feature="list", since="0.2.8")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.8") )]
     pub fn tail<'a>(&'a self) -> &'a Self {
         match self {
             &Cons(_, ref cdr) => cdr,
@@ -347,7 +349,7 @@ impl<T> List<T> {
 
     /// Provide a forward iterator
     #[inline]
-    #[stable(feature="list", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
     pub fn iter<'a>(&'a self) -> ListIterator<'a, T> {
         ListIterator{current: self}
     }
@@ -365,7 +367,7 @@ impl<T> List<T> {
     /// # }
     /// ```
     #[inline]
-    #[stable(feature="list", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
     pub fn last(&self) -> &T {
         match *self {
             Cons(ref car, ref cdr) if cdr.is_empty() => &car,
@@ -403,7 +405,9 @@ impl<T> List<T> {
     /// assert_eq!(a_list.get(10), None);
     /// # }
     /// ```
-    #[stable(feature="list",since="0.3.0")]
+    #[cfg_attr(feature = "nightly",
+    stable(feature="list",since="0.3.0")
+)]
     pub fn get<'a>(&'a self, index: u64) -> Option<&'a T> {
         match (0..index).fold(self, |acc, _| acc.tail()) {
             &Cons(ref car,_) => Some(car),
@@ -413,9 +417,9 @@ impl<T> List<T> {
     }
 }
 
-#[stable(feature="list", since="0.2.5")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.5") )]
 impl<'a, T> fmt::Display for List<T> where T: fmt::Display {
-    #[stable(feature="list", since="0.2.5")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.5") )]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         let mut it = self.iter();
         write!(f, "({}{})", it.next().unwrap(), it.fold(
@@ -425,9 +429,9 @@ impl<'a, T> fmt::Display for List<T> where T: fmt::Display {
     }
 }
 
-#[stable(feature="list", since="0.2.5")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.5") )]
 impl<'a, T> fmt::Debug for List<T> where T: fmt::Debug {
-    #[stable(feature="debug", since="0.2.5")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.5") )]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             Cons(ref head, ref tail) => write!(f, "({:?} . {:?})", head, tail),
@@ -438,7 +442,7 @@ impl<'a, T> fmt::Debug for List<T> where T: fmt::Debug {
 }
 
 
-#[stable(feature="list", since="0.2.3")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.3") )]
 impl<T> FromIterator<T> for List<T> {
     /// Build a `List<T>` from a structure implementing `IntoIterator<T>`.
     ///
@@ -458,7 +462,7 @@ impl<T> FromIterator<T> for List<T> {
     /// }
     /// ```
     #[inline]
-    #[stable(feature="list", since="0.2.3")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.3") )]
     fn from_iter<I>(iterable: I) -> List<T> where I: IntoIterator<Item=T> {
             let mut result  = List::new();
             iterable
@@ -470,12 +474,12 @@ impl<T> FromIterator<T> for List<T> {
 }
 
 /// Wraps a List<T> to allow it to be used as an Iterator<T>
-#[stable(feature="list", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
 pub struct ListIterator<'a, T:'a> { current: &'a List<T> }
 
 /// Implementation of Iterator for List. This allows iteration by
 /// link hopping.
-#[stable(feature="list", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
 impl<'a, T> Iterator for ListIterator<'a, T> {
     type Item = &'a T;
 
@@ -514,7 +518,9 @@ impl<'a, T> Iterator for ListIterator<'a, T> {
     /// # }
     /// ```
     #[inline]
-    #[stable(feature="list", since="0.2.8")]
+    #[cfg_attr(feature = "nightly",
+    stable(feature="list", since="0.2.8")
+)]
     fn next(&mut self) -> Option<&'a T> {
         match self.current {
             &Cons(ref head, ref tail) => {
@@ -526,7 +532,7 @@ impl<'a, T> Iterator for ListIterator<'a, T> {
     }
 }
 
-#[stable(feature="list", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
 impl<'a, T> ExactSizeIterator for ListIterator<'a, T> {
     fn len(&self) -> usize {
         self.current.length()
@@ -545,13 +551,13 @@ impl<'a, T> ExactSizeIterator for ListIterator<'a, T> {
 /// assert_eq!(list[0usize], 1);
 /// # }
 /// ```
-#[stable(feature="list", since="0.1.0")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
 impl<T> Index<usize> for List<T> {
-    #[stable(feature="list", since="0.1.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
     type Output = T;
 
     #[inline]
-    #[stable(feature="list", since="0.2.8")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.8") )]
     fn index<'a>(&'a self, _index: usize) -> &'a T {
         &self[_index as u64]
     }
@@ -570,13 +576,13 @@ impl<T> Index<usize> for List<T> {
 /// assert_eq!(list[0usize], 1);
 /// # }
 /// ```
-#[stable(feature="list", since="0.2.0")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.0") )]
 impl<T> Index<u64> for List<T> {
-    #[stable(feature="list", since="0.2.0")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.0") )]
     type Output = T;
 
     #[inline]
-    #[stable(feature="list", since="0.2.8")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.2.8") )]
     fn index<'a>(&'a self, _index: u64) -> &'a T {
         self.get(_index)
             .expect(&format!("list index {} out of range", _index))
@@ -596,16 +602,22 @@ impl<T> Index<u64> for List<T> {
 /// assert_eq!(list[0isize], 1);
 /// # }
 /// ```
-#[stable(feature="list", since="0.1.0")]
-#[deprecated(since="0.2.0", reason="use unsigned indices instead")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
+#[cfg_attr(feature = "nightly",
+    deprecated(since="0.2.0", reason="use unsigned indices instead")
+)]
 impl<T> Index<i64> for List<T> {
-    #[stable(feature="list", since="0.1.0")]
-    #[deprecated(since="0.2.0", reason="use unsigned indices instead")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
+    #[cfg_attr(feature = "nightly",
+        deprecated(since="0.2.0", reason="use unsigned indices instead")
+    )]
     type Output = T;
 
     #[inline]
-    #[stable(feature="list", since="0.1.0")]
-    #[deprecated(since="0.2.0", reason="use unsigned indices instead")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
+    #[cfg_attr(feature = "nightly",
+        deprecated(since="0.2.0", reason="use unsigned indices instead")
+    )]
     fn index<'a>(&'a self, _index: i64) -> &'a T {
         if _index < 0 {
             panic!("attempt to access negative index {}", _index)
@@ -627,16 +639,22 @@ impl<T> Index<i64> for List<T> {
 /// assert_eq!(list[0isize], 1);
 /// # }
 /// ```
-    #[stable(feature="list", since="0.1.0")]
-#[deprecated(since="0.2.5", reason="use unsigned indices instead")]
+#[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
+#[cfg_attr(feature = "nightly",
+    deprecated(since="0.2.0", reason="use unsigned indices instead")
+)]
 impl<T> Index<isize> for List<T> {
-    #[stable(feature="list", since="0.1.0")]
-    #[deprecated(since="0.2.5", reason="use unsigned indices instead")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
+    #[cfg_attr(feature = "nightly",
+        deprecated(since="0.2.0", reason="use unsigned indices instead")
+    )]
     type Output = T;
 
     #[inline]
-    #[stable(feature="list", since="0.1.0")]
-    #[deprecated(since="0.2.5", reason="use unsigned indices instead")]
+    #[cfg_attr(feature = "nightly", stable(feature="list", since="0.1.0") )]
+    #[cfg_attr(feature = "nightly",
+        deprecated(since="0.2.0", reason="use unsigned indices instead")
+    )]
     fn index<'a>(&'a self, _index: isize) -> &'a T {
         if _index < 0 {
             panic!("attempt to access negative index {}", _index)


### PR DESCRIPTION
This version contains a lot of beginning work on compatibility with all Rust release channels (issue #13).
## v0.2.8-rc.2

Release Candidate 2 of v0.2.8, should fix build on nightly release channel.
- Made stability annotations conditional on `nightly` Cargo feature flag.
- Code-style improvement for state dump format string
- Re-enabled box pattern feature flag (see #14)
## v0.2.8

Added:
- `List::is_empty()` and `List::tail()` functions (09af01c)
- `list_cell![]` convenience macro (f1f7b05)
- `vec_push_all` workaround (7b06c3b)
- Cargo feature flag for nightly (52de889)

Changed:
- Removed all box patterns in `bytecode` (eae8192) and `list` (09af01c) modules (still present in `State::eval()`)
- Removed all uses of `box_syntax` feature gate (f1f7b05)
